### PR TITLE
Blink fix

### DIFF
--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeActivity.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeActivity.kt
@@ -17,6 +17,8 @@ import fr.groggy.racecontrol.tv.f1tv.Archive
 import fr.groggy.racecontrol.tv.ui.season.browse.SeasonBrowseActivity
 import fr.groggy.racecontrol.tv.ui.settings.SettingsActivity
 import fr.groggy.racecontrol.tv.utils.coroutines.schedule
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import org.threeten.bp.Duration
 import org.threeten.bp.Year
 import javax.inject.Inject
@@ -34,6 +36,8 @@ class HomeActivity : FragmentActivity(R.layout.activity_home) {
     @Inject internal lateinit var seasonService: SeasonService
     private var teaserImage: ImageView? = null
 
+    private var syncJob: Job? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -50,6 +54,7 @@ class HomeActivity : FragmentActivity(R.layout.activity_home) {
         findViewById<View>(R.id.settings).setOnClickListener {
             startActivity(SettingsActivity.intent(this))
         }
+
     }
 
     override fun onStart() {
@@ -58,7 +63,7 @@ class HomeActivity : FragmentActivity(R.layout.activity_home) {
 
         teaserImage?.requestFocus()
 
-        lifecycleScope.launchWhenStarted {
+        syncJob = lifecycleScope.launch {
             schedule(Duration.ofMinutes(1)) {
                 Log.d("Fetching new data", "Lifecycle state is ${lifecycle.currentState}")
                 try {
@@ -77,5 +82,11 @@ class HomeActivity : FragmentActivity(R.layout.activity_home) {
                 }
             }
         }
+    }
+
+    override fun onPause() {
+        syncJob?.cancel()
+        syncJob = null
+        super.onPause()
     }
 }

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeActivity.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeActivity.kt
@@ -72,7 +72,7 @@ class HomeActivity : FragmentActivity(R.layout.activity_home) {
 
                 if (supportFragmentManager.findFragmentByTag(TAG) !is HomeFragment) {
                     supportFragmentManager.commit {
-                        replace(R.id.fragment_container, HomeFragment())
+                        replace(R.id.fragment_container, HomeFragment(), TAG)
                     }
                 }
             }

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
@@ -82,13 +82,24 @@ class HomeFragment : RowsSupportFragment(), OnItemViewClickedListener {
                 homeEntriesAdapter.add(sessionsListRow)
                 homeEntriesAdapter.add(archivesRow)
             } else {
-                /* Makes the adapter blink :| */
-                homeEntriesAdapter.replace(0, sessionsListRow)
+
+                /* Compare the old list to the new to see if it needs updating */
+                if (!hasMatchingSessions(existingListRow, sessionsListRow)) {
+                    homeEntriesAdapter.replace(0, sessionsListRow)
+                }
             }
         } else {
             onEmptySeason()
         }
     }
+
+    private fun hasMatchingSessions(
+        existingListRow: ListRow,
+        sessionsListRow: ListRow
+    ) = (existingListRow.adapter.size() == sessionsListRow.adapter.size() // Do we have the same number of items
+            || (0 until existingListRow.adapter.size()).all { index -> // If so, do the sessions in each match in order?
+        existingListRow.adapter[index] as Session == sessionsListRow.adapter[index] as Session
+    })
 
     private fun onEmptySeason() {
         /* Session wasn't started yet, just add the archive */

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
@@ -119,7 +119,9 @@ class HomeFragment : RowsSupportFragment(), OnItemViewClickedListener {
             val listRowAdapter = existingListRow.adapter as ArrayObjectAdapter
             existingListRow to listRowAdapter
         }
-        listRowAdapter.setItems(sessions, Session.diffCallback)
+        if (existingListRow == null || !hasMatchingSessions(existingListRow, listRow)) {
+            listRowAdapter.setItems(sessions, Session.diffCallback)
+        }
         return listRow
     }
 

--- a/app/src/main/java/fr/groggy/racecontrol/tv/utils/coroutines/scheduling.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/utils/coroutines/scheduling.kt
@@ -1,10 +1,14 @@
 package fr.groggy.racecontrol.tv.utils.coroutines
 
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import org.threeten.bp.Duration
 
-suspend fun schedule(duration: Duration, f: suspend () -> Any) {
-    while (true) {
+suspend fun CoroutineScope.schedule(duration: Duration, f: suspend () -> Any) {
+    while (isActive) {
         f()
         delay(duration.toMillis())
     }


### PR DESCRIPTION
There were a couple of issues causing the blinking on the home screen and on the season browser. I haven't checked other screens yet, but my investigation told me that the DiffUtils/DiffCallback didn't seem to be working as expected.

For this I instead manually do a check before setting the items to see if there is a difference. Now it will only blink once when the content for the row is changing.

There was another issue with the way the coroutines were set up. They were being scheduled on start, every time the screen restarted. The schedule job was not being cancelled as the scope that it was being created is is only cancelled in `onDestroy()`, ending up with multiple instances of the refresh happening. If you went back and forth a few times you would see the refresh happening more and more frequently. Not a huge issue, but during my testing I set the refresh to every 10 seconds and I could consistently make the data refetch every couple of seconds by entering and exiting the season browser screen a few times.  So I am manually cancelling the scheduled job in onStop on both the home screen and the season browser. This reduced the frequency of the blinking, even before resolving the blinking itself.



